### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd build
 cmake ..
 make
 ```
-The executable `Client` is created and can be executed.
+The executable `THREATS` is created and can be executed.
 
 ### Licence
 


### PR DESCRIPTION
Changes the `README` to reflect the executable being `THREATS` rather than `Client`